### PR TITLE
Attempt at embedding the `Ref` in the `Buffer` structure

### DIFF
--- a/allow_pin/arm_sizes
+++ b/allow_pin/arm_sizes
@@ -1,15 +1,20 @@
    text	   data	    bss	    dec	    hex	filename
   46464	      0	      0	  46464	   b580	target/thumbv6m-none-eabi/opt-1/examples/complex_dynamic_type
   45114	      0	      0	  45114	   b03a	target/thumbv6m-none-eabi/opt-2/examples/complex_dynamic_type
-  45118	      0	      0	  45118	   b03e	target/thumbv6m-none-eabi/opt-3/examples/complex_dynamic_type
-  42158	      0	      0	  42158	   a4ae	target/thumbv6m-none-eabi/opt-s/examples/complex_dynamic_type
+  45122	      0	      0	  45122	   b042	target/thumbv6m-none-eabi/opt-3/examples/complex_dynamic_type
+  42162	      0	      0	  42162	   a4b2	target/thumbv6m-none-eabi/opt-s/examples/complex_dynamic_type
   33299	      0	      0	  33299	   8213	target/thumbv6m-none-eabi/opt-z/examples/complex_dynamic_type
-  37956	      0	      0	  37956	   9444	target/thumbv6m-none-eabi/opt-1/examples/complex_full_dynamic
+  48008	      0	      0	  48008	   bb88	target/thumbv6m-none-eabi/opt-1/examples/complex_flexible_allow_ref
+  40488	      0	      0	  40488	   9e28	target/thumbv6m-none-eabi/opt-2/examples/complex_flexible_allow_ref
+  40528	      0	      0	  40528	   9e50	target/thumbv6m-none-eabi/opt-3/examples/complex_flexible_allow_ref
+  40228	      0	      0	  40228	   9d24	target/thumbv6m-none-eabi/opt-s/examples/complex_flexible_allow_ref
+  40020	      0	      0	  40020	   9c54	target/thumbv6m-none-eabi/opt-z/examples/complex_flexible_allow_ref
+  37952	      0	      0	  37952	   9440	target/thumbv6m-none-eabi/opt-1/examples/complex_full_dynamic
   29136	      0	      0	  29136	   71d0	target/thumbv6m-none-eabi/opt-2/examples/complex_full_dynamic
-  29136	      0	      0	  29136	   71d0	target/thumbv6m-none-eabi/opt-3/examples/complex_full_dynamic
-  27600	      0	      0	  27600	   6bd0	target/thumbv6m-none-eabi/opt-s/examples/complex_full_dynamic
+  29140	      0	      0	  29140	   71d4	target/thumbv6m-none-eabi/opt-3/examples/complex_full_dynamic
+  27596	      0	      0	  27596	   6bcc	target/thumbv6m-none-eabi/opt-s/examples/complex_full_dynamic
   29720	      0	      0	  29720	   7418	target/thumbv6m-none-eabi/opt-z/examples/complex_full_dynamic
-  31632	      0	      0	  31632	   7b90	target/thumbv6m-none-eabi/opt-1/examples/complex_no_dynamic
+  31628	      0	      0	  31628	   7b8c	target/thumbv6m-none-eabi/opt-1/examples/complex_no_dynamic
   28480	      0	      0	  28480	   6f40	target/thumbv6m-none-eabi/opt-2/examples/complex_no_dynamic
   28480	      0	      0	  28480	   6f40	target/thumbv6m-none-eabi/opt-3/examples/complex_no_dynamic
   28148	      0	      0	  28148	   6df4	target/thumbv6m-none-eabi/opt-s/examples/complex_no_dynamic
@@ -19,6 +24,11 @@
     144	      0	      0	    144	     90	target/thumbv6m-none-eabi/opt-3/examples/hello_world_dynamic_type
     128	      0	      0	    128	     80	target/thumbv6m-none-eabi/opt-s/examples/hello_world_dynamic_type
     124	      0	      0	    124	     7c	target/thumbv6m-none-eabi/opt-z/examples/hello_world_dynamic_type
+    144	      0	      0	    144	     90	target/thumbv6m-none-eabi/opt-1/examples/hello_world_flexible_allow_ref
+    132	      0	      0	    132	     84	target/thumbv6m-none-eabi/opt-2/examples/hello_world_flexible_allow_ref
+    136	      0	      0	    136	     88	target/thumbv6m-none-eabi/opt-3/examples/hello_world_flexible_allow_ref
+    132	      0	      0	    132	     84	target/thumbv6m-none-eabi/opt-s/examples/hello_world_flexible_allow_ref
+    128	      0	      0	    128	     80	target/thumbv6m-none-eabi/opt-z/examples/hello_world_flexible_allow_ref
     208	      0	      0	    208	     d0	target/thumbv6m-none-eabi/opt-1/examples/hello_world_full_dynamic
     140	      0	      0	    140	     8c	target/thumbv6m-none-eabi/opt-2/examples/hello_world_full_dynamic
     140	      0	      0	    140	     8c	target/thumbv6m-none-eabi/opt-3/examples/hello_world_full_dynamic

--- a/allow_pin/examples/complex_flexible_allow_ref.rs
+++ b/allow_pin/examples/complex_flexible_allow_ref.rs
@@ -1,0 +1,159 @@
+//! An example that makes many different system calls with many different buffer
+//! sizes (using generics and lots of random numbers). Intended to test how the
+//! code size scales to large apps that use many drivers.
+
+#![no_main]
+#![no_std]
+
+use allow_pin::{ErrorCode, command, flexible_allow_ref::allow::*};
+use core::pin::{Pin, pin};
+
+/// Using the specified driver number, write the given buffer to the given RO
+/// Allow ID and read the given buffer from the given RW Allow ID, returning its
+/// contents. This intentionally does not know the buffer sizes at compile time,
+/// as it's simulating an API working on data provided by an external crate.
+fn api<const DRIVER_NUM: u32, const RO_BUFFER: u32, const RW_BUFFER: u32>(
+    mut ro_buffer_ref: Pin<&mut Ref<Ro, u8>>,
+    mut rw_buffer_ref: Pin<&mut Ref<Rw, u8>>,
+) -> Result<(), ErrorCode> {
+    ro_buffer_ref.as_mut().allow(DRIVER_NUM, RO_BUFFER)?;
+    rw_buffer_ref.as_mut().allow(DRIVER_NUM, RW_BUFFER)?;
+    // Subscribe goes here.
+    // Dummy command invocation to clobber registers and add an error return
+    // path.
+    command(DRIVER_NUM, RO_BUFFER, RW_BUFFER, 0)?;
+    // Yield goes here.
+    // Perform unallows.
+    ro_buffer_ref.unallow();
+    rw_buffer_ref.unallow();
+    Ok(())
+}
+
+/// Pretend application-crate function that creates the allow buffers and then
+/// uses them with api().
+fn app<
+    const DRIVER_NUM: u32,
+    const RO_BUFFER: u32,
+    const RW_BUFFER: u32,
+    const RO_LEN: usize,
+    const RW_LEN: usize,
+>(
+    ro_data: [u8; RO_LEN],
+) -> Result<[u8; RW_LEN], ErrorCode> {
+    let mut ro_buffer = pin!(Buffer::<Ro, u8, RO_LEN>::from(ro_data));
+    let mut rw_buffer = pin!(Buffer::<Rw, u8, RW_LEN>::from([0; RW_LEN]));
+    api::<DRIVER_NUM, RO_BUFFER, RW_BUFFER>(
+        ro_buffer.as_mut().allow_ref(),
+        rw_buffer.as_mut().allow_ref(),
+    )?;
+    Ok(*rw_buffer.unallow())
+}
+
+#[unsafe(no_mangle)]
+fn _start() -> Result<(), u32> {
+    // These buffer sizes, driver numbers, and buffer numbers were
+    // randomly-generated.
+    let buffer = [0; 40];
+    let buffer: [_; 81] = app::<8198, 9, 9, _, _>(buffer)?;
+    let buffer: [_; 70] = app::<8388, 7, 0, _, _>(buffer)?;
+    let buffer: [_; 24] = app::<9167, 3, 2, _, _>(buffer)?;
+    let buffer: [_; 54] = app::<0543, 0, 7, _, _>(buffer)?;
+    let buffer: [_; 37] = app::<5527, 7, 0, _, _>(buffer)?;
+    let buffer: [_; 14] = app::<1639, 2, 8, _, _>(buffer)?;
+    let buffer: [_; 72] = app::<4817, 3, 8, _, _>(buffer)?;
+    let buffer: [_; 15] = app::<4381, 8, 9, _, _>(buffer)?;
+    let buffer: [_; 37] = app::<0162, 8, 0, _, _>(buffer)?;
+    let buffer: [_; 42] = app::<2364, 0, 3, _, _>(buffer)?;
+    let buffer: [_; 99] = app::<7292, 4, 0, _, _>(buffer)?;
+    let buffer: [_; 39] = app::<7764, 7, 0, _, _>(buffer)?;
+    let buffer: [_; 30] = app::<4322, 3, 3, _, _>(buffer)?;
+    let buffer: [_; 44] = app::<1019, 7, 0, _, _>(buffer)?;
+    let buffer: [_; 37] = app::<1919, 3, 0, _, _>(buffer)?;
+    let buffer: [_; 24] = app::<2672, 9, 8, _, _>(buffer)?;
+    let buffer: [_; 54] = app::<0243, 8, 4, _, _>(buffer)?;
+    let buffer: [_; 52] = app::<9158, 4, 2, _, _>(buffer)?;
+    let buffer: [_; 46] = app::<0521, 2, 8, _, _>(buffer)?;
+    let buffer: [_; 56] = app::<2717, 9, 9, _, _>(buffer)?;
+    let buffer: [_; 52] = app::<0302, 8, 3, _, _>(buffer)?;
+    let buffer: [_; 26] = app::<4812, 0, 5, _, _>(buffer)?;
+    let buffer: [_; 80] = app::<2798, 7, 4, _, _>(buffer)?;
+    let buffer: [_; 60] = app::<3450, 3, 9, _, _>(buffer)?;
+    let buffer: [_; 50] = app::<6942, 6, 8, _, _>(buffer)?;
+    let buffer: [_; 50] = app::<7943, 3, 1, _, _>(buffer)?;
+    let buffer: [_; 16] = app::<6614, 4, 9, _, _>(buffer)?;
+    let buffer: [_; 54] = app::<6537, 1, 7, _, _>(buffer)?;
+    let buffer: [_; 15] = app::<1619, 5, 3, _, _>(buffer)?;
+    let buffer: [_; 19] = app::<7755, 3, 0, _, _>(buffer)?;
+    let buffer: [_; 85] = app::<0814, 9, 7, _, _>(buffer)?;
+    let buffer: [_; 50] = app::<8341, 8, 8, _, _>(buffer)?;
+    let buffer: [_; 65] = app::<2333, 7, 5, _, _>(buffer)?;
+    let buffer: [_; 34] = app::<9340, 1, 0, _, _>(buffer)?;
+    let buffer: [_; 81] = app::<1374, 9, 9, _, _>(buffer)?;
+    let buffer: [_; 79] = app::<3606, 2, 4, _, _>(buffer)?;
+    let buffer: [_; 59] = app::<2566, 8, 5, _, _>(buffer)?;
+    let buffer: [_; 39] = app::<3027, 5, 3, _, _>(buffer)?;
+    let buffer: [_; 20] = app::<8905, 6, 5, _, _>(buffer)?;
+    let buffer: [_; 43] = app::<9119, 8, 4, _, _>(buffer)?;
+    let buffer: [_; 30] = app::<2019, 7, 8, _, _>(buffer)?;
+    let buffer: [_; 81] = app::<6507, 2, 0, _, _>(buffer)?;
+    let buffer: [_; 15] = app::<5055, 0, 3, _, _>(buffer)?;
+    let buffer: [_; 70] = app::<7550, 9, 2, _, _>(buffer)?;
+    let buffer: [_; 86] = app::<7760, 7, 3, _, _>(buffer)?;
+    let buffer: [_; 73] = app::<7275, 6, 6, _, _>(buffer)?;
+    let buffer: [_; 35] = app::<5457, 7, 1, _, _>(buffer)?;
+    let buffer: [_; 43] = app::<3421, 2, 0, _, _>(buffer)?;
+    let buffer: [_; 13] = app::<5221, 6, 0, _, _>(buffer)?;
+    let buffer: [_; 33] = app::<5808, 0, 0, _, _>(buffer)?;
+    let buffer: [_; 83] = app::<9534, 2, 8, _, _>(buffer)?;
+    let buffer: [_; 77] = app::<5818, 9, 4, _, _>(buffer)?;
+    let buffer: [_; 60] = app::<8619, 4, 9, _, _>(buffer)?;
+    let buffer: [_; 56] = app::<7449, 3, 3, _, _>(buffer)?;
+    let buffer: [_; 39] = app::<3627, 2, 8, _, _>(buffer)?;
+    let buffer: [_; 81] = app::<2614, 0, 4, _, _>(buffer)?;
+    let buffer: [_; 79] = app::<8430, 4, 9, _, _>(buffer)?;
+    let buffer: [_; 97] = app::<0438, 2, 8, _, _>(buffer)?;
+    let buffer: [_; 30] = app::<0392, 4, 6, _, _>(buffer)?;
+    let buffer: [_; 33] = app::<6581, 6, 9, _, _>(buffer)?;
+    let buffer: [_; 42] = app::<5619, 1, 3, _, _>(buffer)?;
+    let buffer: [_; 89] = app::<3794, 1, 3, _, _>(buffer)?;
+    let buffer: [_; 74] = app::<5252, 0, 4, _, _>(buffer)?;
+    let buffer: [_; 45] = app::<3645, 2, 3, _, _>(buffer)?;
+    let buffer: [_; 83] = app::<3779, 2, 7, _, _>(buffer)?;
+    let buffer: [_; 58] = app::<9797, 6, 7, _, _>(buffer)?;
+    let buffer: [_; 93] = app::<5284, 0, 5, _, _>(buffer)?;
+    let buffer: [_; 64] = app::<4136, 8, 4, _, _>(buffer)?;
+    let buffer: [_; 49] = app::<4046, 8, 5, _, _>(buffer)?;
+    let buffer: [_; 72] = app::<6158, 4, 3, _, _>(buffer)?;
+    let buffer: [_; 41] = app::<9892, 3, 4, _, _>(buffer)?;
+    let buffer: [_; 26] = app::<8264, 5, 3, _, _>(buffer)?;
+    let buffer: [_; 27] = app::<7374, 5, 2, _, _>(buffer)?;
+    let buffer: [_; 65] = app::<0320, 8, 9, _, _>(buffer)?;
+    let buffer: [_; 24] = app::<8534, 1, 9, _, _>(buffer)?;
+    let buffer: [_; 30] = app::<3259, 9, 5, _, _>(buffer)?;
+    let buffer: [_; 60] = app::<2876, 2, 3, _, _>(buffer)?;
+    let buffer: [_; 44] = app::<7852, 5, 7, _, _>(buffer)?;
+    let buffer: [_; 39] = app::<4533, 4, 3, _, _>(buffer)?;
+    let buffer: [_; 79] = app::<2892, 9, 0, _, _>(buffer)?;
+    let buffer: [_; 53] = app::<5847, 7, 1, _, _>(buffer)?;
+    let buffer: [_; 63] = app::<3671, 0, 3, _, _>(buffer)?;
+    let buffer: [_; 17] = app::<5335, 4, 3, _, _>(buffer)?;
+    let buffer: [_; 63] = app::<3248, 7, 4, _, _>(buffer)?;
+    let buffer: [_; 28] = app::<5780, 5, 9, _, _>(buffer)?;
+    let buffer: [_; 93] = app::<3134, 8, 5, _, _>(buffer)?;
+    let buffer: [_; 18] = app::<5617, 0, 2, _, _>(buffer)?;
+    let buffer: [_; 68] = app::<9266, 2, 9, _, _>(buffer)?;
+    let buffer: [_; 35] = app::<2495, 6, 3, _, _>(buffer)?;
+    let buffer: [_; 36] = app::<7126, 4, 8, _, _>(buffer)?;
+    let buffer: [_; 47] = app::<4723, 6, 9, _, _>(buffer)?;
+    let buffer: [_; 94] = app::<0555, 5, 2, _, _>(buffer)?;
+    let buffer: [_; 85] = app::<6026, 7, 3, _, _>(buffer)?;
+    let buffer: [_; 17] = app::<3209, 2, 2, _, _>(buffer)?;
+    let buffer: [_; 80] = app::<6825, 6, 5, _, _>(buffer)?;
+    let buffer: [_; 27] = app::<0985, 1, 2, _, _>(buffer)?;
+    let buffer: [_; 99] = app::<9544, 3, 3, _, _>(buffer)?;
+    let buffer: [_; 44] = app::<0024, 5, 3, _, _>(buffer)?;
+    let buffer: [_; 42] = app::<9456, 3, 0, _, _>(buffer)?;
+    let buffer: [_; 40] = app::<7930, 4, 8, _, _>(buffer)?;
+    let _ = buffer;
+    Ok(())
+}

--- a/allow_pin/examples/hello_world_flexible_allow_ref.rs
+++ b/allow_pin/examples/hello_world_flexible_allow_ref.rs
@@ -1,0 +1,15 @@
+#![no_main]
+#![no_std]
+
+use allow_pin::{command, flexible_allow_ref::allow::*};
+use core::pin::pin;
+
+#[unsafe(no_mangle)]
+fn _start() -> Result<(), u32> {
+    let mut buffer = pin!(Buffer::<Ro, u8, _>::from(*b"hi"));
+    buffer.as_mut().allow(0x1, 0x1)?;
+
+    command(0x1, 0x1, 14, 0)?;
+    // Wait for an upcall here.
+    Ok(())
+}

--- a/allow_pin/riscv_sizes
+++ b/allow_pin/riscv_sizes
@@ -4,6 +4,11 @@
   54758	      0	      0	  54758	   d5e6	target/riscv32imc-unknown-none-elf/opt-3/examples/complex_dynamic_type
   51272	      0	      0	  51272	   c848	target/riscv32imc-unknown-none-elf/opt-s/examples/complex_dynamic_type
   35403	      0	      0	  35403	   8a4b	target/riscv32imc-unknown-none-elf/opt-z/examples/complex_dynamic_type
+  60846	      0	      0	  60846	   edae	target/riscv32imc-unknown-none-elf/opt-1/examples/complex_flexible_allow_ref
+  54336	      0	      0	  54336	   d440	target/riscv32imc-unknown-none-elf/opt-2/examples/complex_flexible_allow_ref
+  54772	      0	      0	  54772	   d5f4	target/riscv32imc-unknown-none-elf/opt-3/examples/complex_flexible_allow_ref
+  53592	      0	      0	  53592	   d158	target/riscv32imc-unknown-none-elf/opt-s/examples/complex_flexible_allow_ref
+  41992	      0	      0	  41992	   a408	target/riscv32imc-unknown-none-elf/opt-z/examples/complex_flexible_allow_ref
   48110	      0	      0	  48110	   bbee	target/riscv32imc-unknown-none-elf/opt-1/examples/complex_full_dynamic
   41028	      0	      0	  41028	   a044	target/riscv32imc-unknown-none-elf/opt-2/examples/complex_full_dynamic
   41028	      0	      0	  41028	   a044	target/riscv32imc-unknown-none-elf/opt-3/examples/complex_full_dynamic
@@ -19,6 +24,11 @@
     132	      0	      0	    132	     84	target/riscv32imc-unknown-none-elf/opt-3/examples/hello_world_dynamic_type
     104	      0	      0	    104	     68	target/riscv32imc-unknown-none-elf/opt-s/examples/hello_world_dynamic_type
     104	      0	      0	    104	     68	target/riscv32imc-unknown-none-elf/opt-z/examples/hello_world_dynamic_type
+    142	      0	      0	    142	     8e	target/riscv32imc-unknown-none-elf/opt-1/examples/hello_world_flexible_allow_ref
+    134	      0	      0	    134	     86	target/riscv32imc-unknown-none-elf/opt-2/examples/hello_world_flexible_allow_ref
+    136	      0	      0	    136	     88	target/riscv32imc-unknown-none-elf/opt-3/examples/hello_world_flexible_allow_ref
+    130	      0	      0	    130	     82	target/riscv32imc-unknown-none-elf/opt-s/examples/hello_world_flexible_allow_ref
+    126	      0	      0	    126	     7e	target/riscv32imc-unknown-none-elf/opt-z/examples/hello_world_flexible_allow_ref
     148	      0	      0	    148	     94	target/riscv32imc-unknown-none-elf/opt-1/examples/hello_world_full_dynamic
     134	      0	      0	    134	     86	target/riscv32imc-unknown-none-elf/opt-2/examples/hello_world_full_dynamic
     134	      0	      0	    134	     86	target/riscv32imc-unknown-none-elf/opt-3/examples/hello_world_full_dynamic

--- a/allow_pin/src/allow_ref.rs
+++ b/allow_pin/src/allow_ref.rs
@@ -1,0 +1,76 @@
+//! A design based around the `allow::Ref` type, which is a type that can point
+//! to both 'static and stack-based buffers. `allow::Ref` itself is type (and
+//! lifetime)-erased to avoid monomorphization bloat in APIs. However, it is
+//! limited to only RO Allows or only RW Allows (because only allow::Ref<Ro> can
+//! be created from a `&'static [u8]`).
+
+pub type ErrorCode = u32;
+
+pub mod allow {
+    use core::ptr::null_mut;
+    use crate::*;
+
+    /// A reference to something that can be shared with the kernel via the
+    /// Read-Only Allow system call (and if P is Rw, read-write Allow).
+    pub struct Ref<P: Permissions, T: Allowable> {
+        // The lifetime is erased to 'static here. There is no correct lifetime to
+        // write when an AllowRef is embedded inside a Buffer.
+        buffer: P::BufRef<'static, T>,
+        // APIs need to be able to retrieve mutable references to the buffer
+        // (for RW Allow), which requires that they have an exclusive reference
+        // to the Ref. However, giving an &mut reference to the Ref would allow
+        // the buffer to replace the Ref and forget it, which would prevent the
+        // unallow from occurring before the buffer is dropped. To prevent that,
+        // we pin the Ref as well.
+        _pinned: PhantomPinned,
+        share_info: Option<ShareInfo>,
+    }
+
+    impl<P: Permissions, T: Allowable> Ref<P, T> {
+        fn unshare_if_shared(self: Pin<&mut Self>) {
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            let Some(ref info) = this.share_info else { return };
+            unsafe {
+                dynamic_allow(info.driver_num, info.buffer_num, null_mut(), 0, info.allow_type);
+            }
+            this.share_info = None;
+        }
+    }
+
+    struct ShareInfo {
+        allow_type: DynamicType,
+        driver_num: u32,
+        buffer_num: u32,
+    }
+
+    /// Trait representing an allowable type.
+    pub trait Allowable: FromBytes + IntoBytes + 'static {}
+    impl<T: FromBytes + IntoBytes + ?Sized + 'static> Allowable for T {}
+
+    /// A type that represents whether a `Ref` has write access to a buffer.
+    pub trait Permissions: sealed::Sealed {
+        type BufRef<'b, T: Allowable>;
+        // Only exists within the context of this design exploration; would not
+        // exist in libtock-rs (because Permissions replaces StaticType
+        // entirely).
+        type Static: StaticType;
+    }
+
+    // Permissions implementations.
+    pub enum Ro {}
+    impl sealed::Sealed for Ro {}
+    impl Permissions for Ro {
+        type BufRef<'b, T: Allowable> = &'b T;
+        type Static = StaticRo;
+    }
+    pub enum Rw {}
+    impl sealed::Sealed for Rw {}
+    impl Permissions for Rw {
+        type BufRef<'b, T: Allowable> = &'b mut T;
+        type Static = StaticRw;
+    }
+
+    mod sealed {
+        pub trait Sealed {}
+    }
+}

--- a/allow_pin/src/flexible_allow_ref.rs
+++ b/allow_pin/src/flexible_allow_ref.rs
@@ -1,0 +1,237 @@
+//! A design based around the `allow::Ref` type, which is a type that can point
+//! to both 'static and stack-based buffers. `allow::Ref` itself is type (and
+//! lifetime)-erased to avoid monomorphization bloat in APIs. However, it is
+//! limited to only RO Allows or only RW Allows (because only allow::Ref<Ro> can
+//! be created from a `&'static [u8]`).
+
+pub type ErrorCode = u32;
+
+pub mod allow {
+    use crate::*;
+    use core::ptr::null_mut;
+
+    /// A reference to something that can be shared with the kernel via the
+    /// Read-Only Allow system call (and if P is Rw, read-write Allow).
+    pub struct Ref<P: Permissions, T>
+    where
+        [T]: Allowable,
+    {
+        // The lifetime is erased to 'static here. There is no correct lifetime to
+        // write when an AllowRef is embedded inside a Buffer.
+        buffer: P::BufRef<'static, [T]>,
+        // APIs need to be able to retrieve mutable references to the buffer
+        // (for RW Allow), which requires that they have an exclusive reference
+        // to the Ref. However, giving an &mut reference to the Ref would allow
+        // the buffer to replace the Ref and forget it, which would prevent the
+        // unallow from occurring before the buffer is dropped. To prevent that,
+        // we pin the Ref as well.
+        _pinned: PhantomPinned,
+        share_info: Option<ShareInfo>,
+    }
+
+    impl<P: Permissions, T> Ref<P, T>
+    where
+        [T]: Allowable,
+    {
+        fn unshare_if_shared(&mut self) {
+            let Some(ref info) = self.share_info else {
+                return;
+            };
+            unsafe {
+                static_allow::<P::Static>(info.driver_num, info.buffer_num, null_mut(), 0);
+            }
+            self.share_info = None;
+        }
+    }
+
+    impl<P: Permissions, T> Ref<P, T>
+    where
+        [T]: Allowable,
+    {
+        pub fn allow(
+            self: Pin<&mut Ref<P, T>>,
+            driver_num: u32,
+            buffer_num: u32,
+        ) -> Result<(), ErrorCode> {
+            if self.share_info.is_some() {
+                return Err(3);
+            }
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            let (variant, r1, _, _) = unsafe {
+                static_allow::<P::Static>(
+                    driver_num,
+                    buffer_num,
+                    &mut this.buffer as *mut _ as *mut u8,
+                    size_of_val(&this.buffer),
+                )
+            };
+            if variant == 2 {
+                return Err(r1.addr() as u32);
+            }
+            this.share_info = Some(ShareInfo {
+                driver_num,
+                buffer_num,
+            });
+            Ok(())
+        }
+
+        pub fn unallow(self: Pin<&mut Ref<P, T>>) {
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            this.unshare_if_shared();
+        }
+    }
+
+    impl<T> From<&'static [T]> for Ref<Ro, T>
+    where
+        [T]: Allowable,
+    {
+        fn from(value: &'static [T]) -> Self {
+            Self {
+                buffer: value,
+                _pinned: Default::default(),
+                share_info: None,
+            }
+        }
+    }
+
+    impl<T> From<&'static mut [T]> for Ref<Rw, T>
+    where
+        [T]: Allowable,
+    {
+        fn from(value: &'static mut [T]) -> Self {
+            Self {
+                buffer: value,
+                _pinned: Default::default(),
+                share_info: None,
+            }
+        }
+    }
+
+    impl<T, P: Permissions> Drop for Ref<P, T>
+    where
+        [T]: Allowable,
+    {
+        fn drop(&mut self) {
+            self.unshare_if_shared();
+        }
+    }
+
+    struct ShareInfo {
+        driver_num: u32,
+        buffer_num: u32,
+    }
+
+    /// Trait representing an allowable type.
+    pub trait Allowable: FromBytes + IntoBytes + 'static {}
+    impl<T: FromBytes + IntoBytes + ?Sized + 'static> Allowable for T {}
+
+    /// A type that represents whether a `Ref` has write access to a buffer.
+    pub trait Permissions: sealed::Sealed {
+        type BufRef<'b, T: Allowable + ?Sized>;
+        // Only exists within the context of this design exploration; would not
+        // exist in libtock-rs (because Permissions replaces StaticType
+        // entirely).
+        type Static: StaticType;
+    }
+
+    // Permissions implementations.
+    pub enum Ro {}
+    impl sealed::Sealed for Ro {}
+    impl Permissions for Ro {
+        type BufRef<'b, B: Allowable + ?Sized> = &'b B;
+        type Static = StaticRo;
+    }
+    pub enum Rw {}
+    impl sealed::Sealed for Rw {}
+    impl Permissions for Rw {
+        type BufRef<'b, B: Allowable + ?Sized> = &'b mut B;
+        type Static = StaticRw;
+    }
+
+    mod sealed {
+        pub trait Sealed {}
+    }
+
+    pub struct Buffer<P: Permissions, T, const N: usize>
+    where
+        [T]: Allowable,
+    {
+        allow_ref: Ref<P, T>,
+        buffer: [T; N],
+    }
+
+    impl<T, const N: usize> From<[T; N]> for Buffer<Ro, T, N>
+    where
+        [T]: Allowable,
+    {
+        fn from(value: [T; N]) -> Self {
+            let reference = unsafe { core::mem::transmute(&value as &[T]) };
+
+            Self {
+                buffer: value,
+                allow_ref: Ref {
+                    buffer: reference,
+                    _pinned: Default::default(),
+                    share_info: None,
+                },
+            }
+        }
+    }
+
+    impl<T, const N: usize> From<[T; N]> for Buffer<Rw, T, N>
+    where
+        [T]: Allowable,
+    {
+        fn from(mut value: [T; N]) -> Self {
+            let reference = unsafe { core::mem::transmute(&mut value as &mut [T]) };
+
+            Self {
+                buffer: value,
+                allow_ref: Ref {
+                    buffer: reference,
+                    _pinned: Default::default(),
+                    share_info: None,
+                },
+            }
+        }
+    }
+
+    impl<T, P: Permissions, const N: usize> Buffer<P, T, N>
+    where
+        [T]: Allowable,
+    {
+        pub fn buffer(self: Pin<&Buffer<P, T, N>>) -> Option<&[T; N]> {
+            if self.allow_ref.share_info.is_some() {
+                return None;
+            }
+
+            Some(&self.get_ref().buffer)
+        }
+
+        pub fn buffer_mut(self: Pin<&mut Buffer<P, T, N>>) -> Option<&mut [T; N]> {
+            if self.allow_ref.share_info.is_some() {
+                return None;
+            }
+
+            Some(&mut unsafe { Pin::into_inner_unchecked(self) }.buffer)
+        }
+
+        pub fn unallow(self: Pin<&mut Buffer<P, T, N>>) -> &mut [T; N] {
+            let this = unsafe { Pin::into_inner_unchecked(self) };
+            this.allow_ref.unshare_if_shared();
+            &mut this.buffer
+        }
+
+        pub fn allow_ref(self: Pin<&mut Buffer<P, T, N>>) -> Pin<&mut Ref<P, T>> {
+            unsafe { self.map_unchecked_mut(|buffer| &mut buffer.allow_ref) }
+        }
+
+        pub fn allow(
+            self: Pin<&mut Buffer<P, T, N>>,
+            driver_num: u32,
+            buffer_num: u32,
+        ) -> Result<(), ErrorCode> {
+            self.allow_ref().allow(driver_num, buffer_num)
+        }
+    }
+}

--- a/allow_pin/src/lib.rs
+++ b/allow_pin/src/lib.rs
@@ -6,6 +6,7 @@ use core::pin::Pin;
 use core::ptr::null_mut;
 use zerocopy::{FromBytes, IntoBytes};
 
+pub mod allow_ref;
 pub mod dynamic_type;
 pub mod full_dynamic;
 pub mod no_dynamic;

--- a/allow_pin/src/lib.rs
+++ b/allow_pin/src/lib.rs
@@ -8,6 +8,7 @@ use zerocopy::{FromBytes, IntoBytes};
 
 pub mod allow_ref;
 pub mod dynamic_type;
+pub mod flexible_allow_ref;
 pub mod full_dynamic;
 pub mod no_dynamic;
 


### PR DESCRIPTION
## Motivation

The direction I tried to explore in this PR is embedding the `Ref` inside the `Buffer` structure. Unfortunately, something similar to this:

```rust
pub struct Buffer<P: Permissions, T: Allowable + ?Sized> {
    allow_ref: Ref<P, T>,
    buffer: T,
}
```

would not work for me, because:

- implementing `From<T>` for `Buffer<P, T>` requires the latter to be `Sized`
- a variable of type `Pin<&mut Ref<P, [T: N]>>` cannot be cast to a `Pin<&mut Ref<P, [T]>>` (or not as nice as we would previously cast the `Pin<&mut full_dynamic::Buffer<[B; N]>>` to `Pin<&mut full_dynamic::Buffer<[B]>>`)

Because of these aspects, a capsule API that uses an `allow::Ref` would probably look like this:

```rust
fn console_write<const N: usize>(to_write: Pin<&mut allow::Ref<Rw, [u8; N]>>) -> Result<usize, ErrorCode>;
```

## Proposed Design

This inconvenience was caused by the fact that the both the `allow_ref` and `buffer` fields used the same *"buffer-type"*. Thus, I tried to loosen this constraints and ended up with this design:

```rust
pub struct Ref<P: Permissions, T>
where
    [T]: Allowable,
{
    buffer: P::BufRef<'static, [T]>,
    _pinned: PhantomPinned,
    share_info: Option<ShareInfo>,
}

pub struct Buffer<P: Permissions, T, const N: usize>
where
    [T]: Allowable,
{
    allow_ref: Ref<P, T>,
    buffer: [T; N],
}
```

This approach is decently ergonomic in constructing Allow buffers and generating a `Pin<&mut Ref<...>>` based on a `Pin<&mut Buffer<...>>`. Sadly this design increases the memory consumption by **~33%** (performing slightly worse on RISCV).